### PR TITLE
Two fixes to injection script

### DIFF
--- a/javascripts/content_scripts/privly.js
+++ b/javascripts/content_scripts/privly.js
@@ -161,10 +161,11 @@ var privly = {
     for (var i=0; i < textNodes.snapshotLength; i++){
       var item = textNodes.snapshotItem(i);
 
-      var itemText = item.nodeValue;
+      var itemText = item.nodeValue.trim();
 
       privly.privlyReferencesRegex.lastIndex = 0;
       if (privly.privlyReferencesRegex.test(itemText)){
+
         var span = document.createElement("span");
         var lastLastIndex = 0;
         privly.privlyReferencesRegex.lastIndex = 0;


### PR DESCRIPTION
I made two small changes to the injection script.

First, when submitting a [CS capstone project](http://web.engr.oregonstate.edu/cgi-bin/cgiwrap/dmcgrath/classes/14Su/cs271/index.cgi?project=47) I found a case where plaintext links were not being generated correctly. The failure was caused by the whitespace surrounding the URL. The fix is to trim the URL.

The other change is to stop monitoring the page's DOM for changes to attributes. This is an optimization to speed up the script since it is unlikely that we really need to watch the attributes.
