### PR TITLE
Fix javascript swapped on hover

### DIFF
--- a/javascripts/content_scripts/privly.js
+++ b/javascripts/content_scripts/privly.js
@@ -209,6 +209,28 @@ var privly = {
   correctIndirection: {
 
     /**
+     * Test the string for a well formatted Privly-type link
+     * then replace the data-privlyHref attribute if it passes.
+     * @param {node} element The element that receives the data-privlyHref
+     * string if it passes.
+     * @param {string} stringToTest The string whose value
+     * we are interested in copying over.
+     *
+     * @return {boolean} Indicates whether it passed.
+     */
+    testAndCopyOver: function(element, stringToTest) {
+      privly.privlyReferencesRegex.lastIndex = 0;
+      if (privly.privlyReferencesRegex.test(stringToTest)) {
+        privly.privlyReferencesRegex.lastIndex = 0;
+        var results = privly.privlyReferencesRegex.exec(stringToTest);
+        var newHref = privly.makeHref(results[0]);
+        element.setAttribute("data-privlyHref", newHref);
+        return true;
+      }
+      return false;
+    },
+
+    /**
      * Check all the attributes in turn and use the value if it matches.
      * @param {array} elements array of "a" elements.
      * @return {array} Elements not updated by the function.
@@ -221,10 +243,8 @@ var privly = {
           for (var y = 0; y < a.attributes.length; y++) {
             var attrib = a.attributes[y];
             if (attrib.specified === true) {
-              privly.privlyReferencesRegex.lastIndex = 0;
-              if (privly.privlyReferencesRegex.test(attrib.value)) {
-                a.setAttribute("data-privlyHref", attrib.value);
-                same = false;
+              if ( attrib.value.indexOf("privlyInject1") > 0 ) {
+                same = ! privly.correctIndirection.testAndCopyOver(a, attrib.value);
               }
             }
           }
@@ -244,15 +264,8 @@ var privly = {
       var notUpdated = [];
       elements.forEach(
         function(a){
-          privly.privlyReferencesRegex.lastIndex = 0;
-          if (privly.privlyReferencesRegex.test(a.textContent)) {
-
-            // If the href is not present or is on a different domain
-            privly.privlyReferencesRegex.lastIndex = 0;
-            var results = privly.privlyReferencesRegex.exec(a.textContent);
-            var newHref = privly.makeHref(results[0]);
-            a.setAttribute("data-privlyHref", newHref);
-          } else {
+          if ( ! a.textContent.indexOf("privlyInject1") > 0 // Optimization
+            || ! privly.correctIndirection.testAndCopyOver(a, a.textContent) ) {
             notUpdated.push(a);
           }
       });

--- a/javascripts/content_scripts/privly.js
+++ b/javascripts/content_scripts/privly.js
@@ -219,6 +219,7 @@ var privly = {
      * @return {boolean} Indicates whether it passed.
      */
     testAndCopyOver: function(element, stringToTest) {
+      "use strict";
       privly.privlyReferencesRegex.lastIndex = 0;
       if (privly.privlyReferencesRegex.test(stringToTest)) {
         privly.privlyReferencesRegex.lastIndex = 0;
@@ -234,6 +235,7 @@ var privly = {
      * Simulate the Javascript events associated with hovering the element.
      */
     hover: function(elem) {
+      "use strict";
       var ev = document.createEvent( 'Events' );
       ev.initEvent( "mouseover", true, false );
       elem.dispatchEvent( ev );
@@ -248,6 +250,7 @@ var privly = {
      * @return {array} Elements not updated by the function.
      */
     moveFromAttributes: function(elements) {
+      "use strict";
       var notUpdated = [];
       elements.forEach(
         function(a){
@@ -641,6 +644,8 @@ var privly = {
    * @see privly.addListeners
    */
   listenerDOMNodeInserted: function(mutations) {
+    "use strict";
+
     //we check the page a maximum of two times a second
     if (privly.runPending) {
       return;
@@ -715,6 +720,7 @@ var privly = {
    * Toggles the display of links and the iframes injected based on the links.
    */
   toggleInjection: function() {
+    "use strict";
     var iframes = document.getElementsByTagName("iframe");
     for(var i = 0; i < iframes.length; i++) {
       var iframe = iframes[i];
@@ -813,7 +819,7 @@ var privly = {
    * Start this content script if it has not already been started.
    */
   start: function(){
-
+    "use strict";
     if ( !privly.started ) {
 
       privly.toggleInjection();
@@ -839,6 +845,7 @@ var privly = {
    * Stop this content script if it has already been started.
    */
   stop: function(){
+    "use strict";
     if (privly.started) {
       privly.started = false;
       privly.removeListeners();
@@ -862,6 +869,7 @@ var privly = {
    * is a properly formatted string.
    */
   updateWhitelist: function(domainRegexp) {
+    "use strict";
     privly.privlyReferencesRegex = new RegExp(
       "(?:^|\\s+)(https?:\\/\\/){0,1}(" + //protocol
       "priv\\.ly\\/|" + //priv.ly

--- a/javascripts/content_scripts/privly.js
+++ b/javascripts/content_scripts/privly.js
@@ -231,6 +231,18 @@ var privly = {
     },
 
     /**
+     * Simulate the Javascript events associated with hovering the element.
+     */
+    hover: function(elem) {
+      var ev = document.createEvent( 'Events' );
+      ev.initEvent( "mouseover", true, false );
+      elem.dispatchEvent( ev );
+      var ev2 = document.createEvent( 'Events' );
+      ev2.initEvent( "mouseout", true, false );
+      elem.dispatchEvent( ev2 );
+    },
+
+    /**
      * Check all the attributes in turn and use the value if it matches.
      * @param {array} elements array of "a" elements.
      * @return {array} Elements not updated by the function.
@@ -245,6 +257,18 @@ var privly = {
             if (attrib.specified === true) {
               if ( attrib.value.indexOf("privlyInject1") > 0 ) {
                 same = ! privly.correctIndirection.testAndCopyOver(a, attrib.value);
+
+                // The attribute has the injection parameter but it did not pass
+                // replacement. In many cases this indicates the URL will be
+                // swapped in by the host page's JS when the element is hovered
+                // so we hover the element then run it through this process again.
+                if ( same && a.getAttribute("data-privly-hovered") !== "true") {
+                  a.setAttribute("data-privly-hovered", "true");
+                  privly.correctIndirection.hover(a);
+                  var rem = privly.correctIndirection.moveFromAttributes([a]);
+                  rem = privly.correctIndirection.moveFromBody(rem);
+                  same = (rem.length === 1);
+                }
               }
             }
           }


### PR DESCRIPTION
This pull request refactors the functionality in privly.js that supports injecting links that have been modified by the host page. In particular, some sites swap the true URL into the link element once the user hovers the element. With these changes the swapped URL is detected on the element and the element is hovered before being re-processed.

I have not sufficiently tested this to merge since wifi is limited where I am.

#80 