### PR TITLE
fixed deactivation of posting button

### DIFF
--- a/javascripts/background_scripts/posting_process.js
+++ b/javascripts/background_scripts/posting_process.js
@@ -246,7 +246,7 @@ chrome.runtime.onMessage.addListener(
 chrome.runtime.onMessage.addListener(
   function(request, sender, sendResponse) {
     if (request.ask === "PrivlyBtnStatus") {
-      if(ls.getItem("Options:DissableButton") === "true") {
+      if( ls.getItem("Options:DissableButton") === true ) {
         sendResponse({tell: "checked"});
       } else {
         sendResponse({tell: "unchecked"});


### PR DESCRIPTION
The local storage shim library is type coercing `"true"` into `true`. Since the code climate update made the equality check strict, it became impossible to turn off the button.