### PR TITLE
Default app removal

### DIFF
--- a/javascripts/content_scripts/privly.js
+++ b/javascripts/content_scripts/privly.js
@@ -415,7 +415,7 @@ var privly = {
         chrome.extension.sendMessage(
           {privlyOriginalURL: iframeUrl},
           function(response) {
-            if( response.privlyApplicationURL !== undefined ) {
+            if( typeof response.privlyApplicationURL === "string" ) {
               privly.injectLinkApplication(object, response.privlyApplicationURL, frameId);
             }
           });


### PR DESCRIPTION
This pull request makes it so that the only domain that has a default application is the priv.ly (for legacy reasons). In time we will also remove this default application. 

This also updates privly-applications to chrome-extension-master.