### PR TITLE
Fix PrilySpec path

### DIFF
--- a/background.html
+++ b/background.html
@@ -15,7 +15,7 @@
     <script type="text/javascript" src="javascripts/background_scripts/test_loader.js"></script>
 
     <!-- include spec file meta information -->
-    <meta name="PrivlySpec" content="tests/ExtensionSpec.js">
+    <meta name="PrivlySpec" content="javascripts/tests/ExtensionSpec.js">
 
   </head>
 


### PR DESCRIPTION
I'm not sure if the PrivlySpec is still used for the old test system, but as long as there are test files it makes sense to point the spec to the right path.