### PR TITLE
iFrame frameborder attribute already set before

### DIFF
--- a/javascripts/content_scripts/privly.js
+++ b/javascripts/content_scripts/privly.js
@@ -368,7 +368,6 @@ var privly = {
     iFrame.setAttribute("marginwidth","0");
     iFrame.setAttribute("marginheight","0");
     iFrame.setAttribute("height","1px");
-    iFrame.setAttribute("frameborder","0");
     iFrame.setAttribute("style","width: 100%; height: 32px; " +
       "overflow: hidden;");
     iFrame.setAttribute("scrolling","no");


### PR DESCRIPTION
The iFrame `frameborder` attribute is already set
This is similar to the changes made in the [privly-firefox pull request](https://github.com/privly/privly-firefox/pull/49)